### PR TITLE
Add explicit lazy parameter to keywordargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 .venv
 .hypothesis
 dist/
+.python-version

--- a/kslurm/args/arg_types.py
+++ b/kslurm/args/arg_types.py
@@ -225,6 +225,7 @@ class KeywordArg(FlagArg, Generic[S]):
         values: List[str] = [],
         help: str = "",
         values_name: str = "",
+        lazy: bool = False,
     ):
         super().__init__(id=id, match=match, help=help, value=value)
         self.num = num
@@ -232,6 +233,7 @@ class KeywordArg(FlagArg, Generic[S]):
         self.values = values
         self.values_name = values_name
         self.validation_err: Optional[ValidationError] = None
+        self.lazy = lazy
 
     @property
     def values(self) -> List[str]:

--- a/kslurm/args/parser.py
+++ b/kslurm/args/parser.py
@@ -126,30 +126,17 @@ def _group_arg(
     except StopIteration:
         return filter(None, updated_args)
 
-    if group_size:
-        assert isinstance(last_arg, KeywordArg)
+    if (
+        group_size
+        and isinstance(last_arg, KeywordArg)
+        and (isinstance(arg, PositionalArg) or not last_arg.lazy)
+    ):
         new_arg = kcast(last_arg.add_values(it.chain(last_arg.values, [arg.raw_value])))
         new_group_size = group_size - 1
         updated_args = grouped_args
 
-    elif all(
-        [
-            isinstance(last_arg, KeywordArg),
-            _get_keyword_group_size(kcast(last_arg)) == 0,
-            isinstance(arg, PositionalArg),
-        ]
-    ):
-        # all() is not propagating the fact that last_arg is a keyword, so we assert it
-        # here.
-        assert isinstance(last_arg, KeywordArg)
-        new_arg = kcast(last_arg.add_values(it.chain(last_arg.values, [arg.raw_value])))
-        new_group_size = group_size
-        updated_args = grouped_args
-
     elif isinstance(arg, PositionalArg):
-        new_arg = _process_positional(
-            cast(PositionalArg[Any], arg), positional_models, tail_model
-        )
+        new_arg = _process_positional(arg, positional_models, tail_model)
         new_group_size = _get_keyword_group_size(new_arg)
 
     else:

--- a/test/args/arg_templates.py
+++ b/test/args/arg_templates.py
@@ -35,15 +35,25 @@ class Templates:
     )
 
     length_5_keyword: KeywordArg[str] = KeywordArg[str](
-        id="length_5_keyword", match=["--length_5_keyword"], num=5, value=False
+        id="length_5_keyword",
+        match=["--length_5_keyword"],
+        num=5,
+        value=False,
     )
 
     lazy_inf_keyword: KeywordArg[str] = KeywordArg[str](
-        id="lazy_inf_keyword", match=["lazy_inf_keyword"], num=0, value=False
+        id="lazy_inf_keyword",
+        match=["lazy_inf_keyword"],
+        num=-1,
+        value=False,
+        lazy=True,
     )
 
     greedy_inf_keyword: KeywordArg[Union[str, bool]] = KeywordArg[Union[str, bool]](
-        id="greedy_inf_keyword", match=["greedy_inf_keyword"], num=-1, value=False
+        id="greedy_inf_keyword",
+        match=["greedy_inf_keyword"],
+        num=-1,
+        value=False,
     )
 
     positional: PositionalArg[str] = PositionalArg(id="positional", value="pos1")

--- a/test/args/arg_templates.py
+++ b/test/args/arg_templates.py
@@ -6,7 +6,7 @@ from typing import Union
 from kslurm.args.arg_types import FlagArg, KeywordArg, PositionalArg, ShapeArg, TailArg
 
 
-def time(time: str):
+def time_format(time: str):
     if "-" in time:
         days, hhmm = time.split("-")
         hours, min = hhmm.split(":")
@@ -20,7 +20,7 @@ class Templates:
     time: ShapeArg[str] = ShapeArg(
         id="random",
         match=lambda arg: bool(re.match(r"^([0-9]{1,2}-)?[0-9]{1,2}:[0-9]{2}$", arg)),
-        format=time,
+        format=time_format,
         value="03:00",
     )
 

--- a/test/args/models/__init__.py
+++ b/test/args/models/__init__.py
@@ -1,4 +1,5 @@
 from test.args.models.basic import basic_attr, basic_dict
 from test.args.models.no_defaults import no_default_dict, no_default_attr
+from test.args.models.positional_and_shape import pos_and_shape
 
-models = [basic_attr, basic_dict, no_default_attr, no_default_dict]
+models = [basic_attr, basic_dict, no_default_attr, no_default_dict, pos_and_shape]

--- a/test/args/models/basic.py
+++ b/test/args/models/basic.py
@@ -133,7 +133,10 @@ class AttrModel:
     )
 
     length_5_keyword: KeywordArg[str] = KeywordArg(
-        id="length_5_keyword", match=["--length_5_keyword"], num=5, value=False
+        id="length_5_keyword",
+        match=["--length_5_keyword"],
+        num=5,
+        value=False,
     )
 
     tail: TailArg = TailArg()
@@ -163,7 +166,10 @@ typed_dict_model = TypedDictModel(
         id="junk", match=["-j", "--job-template"], num=1, value=False
     ),
     length_5_keyword=KeywordArg[str](
-        id="length_5_keyword", match=["--length_5_keyword"], num=5, value=False
+        id="length_5_keyword",
+        match=["--length_5_keyword"],
+        num=5,
+        value=False,
     ),
     tail=TailArg(),
 )

--- a/test/args/models/no_defaults.py
+++ b/test/args/models/no_defaults.py
@@ -66,7 +66,10 @@ class AttrModel:
     )
 
     length_5_keyword: KeywordArg[str] = KeywordArg(
-        id="length_5_keyword", match=["--length_5_keyword"], num=5, value=None
+        id="length_5_keyword",
+        match=["--length_5_keyword"],
+        num=5,
+        value=None,
     )
 
     tail: TailArg = TailArg()
@@ -91,7 +94,10 @@ typed_dict_model = TypedDictModel(
     gpu=FlagArg(match=["gpu"]),
     number=ShapeArg(match=lambda arg: bool(re.match(r"^[0-9]+$", arg))),
     length_5_keyword=KeywordArg[str](
-        id="length_5_keyword", match=["--length_5_keyword"], num=5, value=None
+        id="length_5_keyword",
+        match=["--length_5_keyword"],
+        num=5,
+        value=None,
     ),
     tail=TailArg(),
 )

--- a/test/args/models/positional_and_shape.py
+++ b/test/args/models/positional_and_shape.py
@@ -2,10 +2,42 @@ from __future__ import absolute_import
 
 import re
 from test.args.models import formatters
+from test.args.models.common import ModelTest, update_model
+from typing import Any, List
 
 import attr
 
 from kslurm.args.arg_types import FlagArg, KeywordArg, PositionalArg, ShapeArg, TailArg
+
+
+def get_tests(model: object) -> List[List[List[Any]]]:
+    return [
+        [
+            [
+                "template",
+                "parcour",
+                "positional",
+                "2",
+                "positional2",
+                "positional3",
+            ]
+        ],
+        [
+            update_model(
+                model,
+                [
+                    "03:00",
+                    None,
+                    "2",
+                    [True, ["parcour"]],
+                    "positional",
+                    "positional2",
+                    "positional3",
+                    [None, []],
+                ],
+            ),
+        ],
+    ]
 
 
 @attr.s(auto_attribs=True)
@@ -32,3 +64,8 @@ class PositionalAndShapeModel:
     positional3: PositionalArg[str] = PositionalArg(id="positional3", value="pos3")
 
     tail: TailArg = TailArg()
+
+
+pos_and_shape = ModelTest(
+    PositionalAndShapeModel(), *get_tests(PositionalAndShapeModel())
+)


### PR DESCRIPTION
Previously, greedy vs lazy infinite args was determined by setting num
to a negative number vs 0. Now, this is set by an explicit parameter
`lazy`, false by default. This allows non-infinite args to be lazy,
allows the defining of 0 length keyword args (essentially the same as
flags), and should make the api more sensible

Resolves #11
