### PR TITLE
Allow kpy load on login node

### DIFF
--- a/kslurm/cli/kpy.py
+++ b/kslurm/cli/kpy.py
@@ -95,6 +95,7 @@ class VenvCache(UserDict[str, Path]):
                 "directory"
             )
         self.venv_cache = Path(pipdir, "venv_archives")
+        self.venv_cache.mkdir(exist_ok=True)
         venvs_re = [
             re.search(r"(.+)\.tar\.gz$", str(f.name)) for f in self.venv_cache.iterdir()
         ]


### PR DESCRIPTION
Allows the loading of saved venvs on the login node. Still no ability to activate such nodes once loaded, so once deactivated, the venv is gone. 

Also includes a hot fix for #16, making <pipdir>/venv_cache if it doesn't exist.

