### PR TITLE
Kpy env switch

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   build:
-    if: ${{ github.event.pull_request.merged == true || contains(github.event_name, 'push') }}
+    if: ${{ github.event.pull_request.merged == true || contains(github.event_name, 'push') && ! contains(github.event.push.sender, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master branch

--- a/kslurm/args/command.py
+++ b/kslurm/args/command.py
@@ -14,7 +14,7 @@ from kslurm.args.parser import ScriptHelp, parse_args
 from kslurm.args.types import WrappedCommand
 from kslurm.exceptions import CommandLineError
 
-_CommandFunc = Callable[..., None]
+_CommandFunc = Callable[..., Optional[int]]
 ModelType = Union[dict[str, Arg[Any, Any]], type]
 
 


### PR DESCRIPTION
The previous iteration would exit the env when a command errored, e.g. if the user loaded an env already created. The new implementation properly handles error situations. It also avoids the need to continually recreate subshells, and in principle allows the avoidance of all subshells.