### PR TITLE
Typer interface and automatic python version detection

### DIFF
--- a/kslurm/args/command.py
+++ b/kslurm/args/command.py
@@ -21,6 +21,12 @@ ModelType = Union[dict[str, Arg[Any, Any]], type]
 ParsedArgs = dict[str, Arg[Any, Any]]
 
 
+class CommandError(Exception):
+    def __init__(self, msg: str, *args: Any):
+        super().__init__(*args)
+        self.msg = msg
+
+
 class CommandArgs:
     _model: Optional[str] = None
     _tail: Optional[str] = None
@@ -219,7 +225,11 @@ def command(
                         else {}
                     ),
                 }
-            return func(**args) or 0
+            try:
+                return func(**args) or 0
+            except CommandError as err:
+                print(err.msg)
+                return 1
 
         return wrapper
 

--- a/kslurm/args/helpers.py
+++ b/kslurm/args/helpers.py
@@ -28,7 +28,7 @@ def get_arg_list(models: ModelType):
         fields = attr.fields(models)
         result: list[Arg[Any, Any]] = []
         for field in fields:
-            if not field.default:
+            if field.default is attr.NOTHING:
                 raise Exception()
             if field.default.num and not getattr(field.type, "__origin__") == list:
                 raise TypeError(f"{field} must be annotated as a list")

--- a/kslurm/args/helpers.py
+++ b/kslurm/args/helpers.py
@@ -28,10 +28,12 @@ def get_arg_list(models: ModelType):
         fields = attr.fields(models)
         result: list[Arg[Any, Any]] = []
         for field in fields:
-            if field.default is attr.NOTHING:
+            if field.default is attr.NOTHING or not field.default:
                 raise Exception()
+            if field.type is attr.NOTHING:
+                raise TypeError(f"{field.name} must be annotated")
             if field.default.num and not getattr(field.type, "__origin__") == list:
-                raise TypeError(f"{field} must be annotated as a list")
+                raise TypeError(f"{field.name} must be annotated as a list")
             extra_args = {
                 **(
                     {"format": field.type}

--- a/kslurm/cli/kpy.py
+++ b/kslurm/cli/kpy.py
@@ -378,8 +378,8 @@ class _ActivateModel:
     script: list[str] = keyword(match=["--script"])
 
 
-@command
-def _activate(args: _ActivateModel):
+@command(typer=True)
+def _activate(name: str, script: list[str] = keyword(["--script"])):
     """Activate a venv already created or loaded
 
     Only works on compute nodes. Use kpy create or kpy load --as on a login node
@@ -391,7 +391,7 @@ def _activate(args: _ActivateModel):
         return 1
 
     index = KpyIndex(slurm_tmp)
-    name = args.name
+    name = name
     if name not in index:
         print(
             f"An environment with the name '{name}' has not yet been initialized. ",
@@ -410,8 +410,8 @@ def _activate(args: _ActivateModel):
         return 1
 
     shell = Shell.get()
-    if args.script:
-        with Path(args.script[0]).open("w") as f:
+    if script:
+        with Path(script[0]).open("w") as f:
             f.write(shell.source(Path(index[name])))
         return 2
     shell.activate(Path(index[name]))

--- a/kslurm/cli/kpy.py
+++ b/kslurm/cli/kpy.py
@@ -277,7 +277,16 @@ def _create(
     if version:
         ver = ["-p", version]
     else:
-        ver = []
+        try:
+            data = sp.run(
+                "eval $($LMOD_CMD bash list python)", shell=True, capture_output=True
+            )
+            if match := re.search(r"(?<=python\/)\d\.\d{1,2}", data.stdout.decode()):
+                ver = ["-p", match[0]]
+            else:
+                ver = []
+        except RuntimeError:
+            ver = []
 
     slurm_tmp = _get_slurm_tmpdir()
     if slurm_tmp:

--- a/kslurm/cli/kpy.py
+++ b/kslurm/cli/kpy.py
@@ -18,7 +18,7 @@ from virtualenv.create import pyenv_cfg  # type: ignore
 
 from kslurm.appconfig import get_config
 from kslurm.args import Subcommand, flag, keyword, positional, shape, subcommand
-from kslurm.args.command import command
+from kslurm.args.command import CommandError, command
 from kslurm.kpyindex import KpyIndex
 from kslurm.shell import Shell
 
@@ -45,16 +45,12 @@ def _get_unique_name(index: KpyIndex, stem: str = "venv", i: int = 0) -> str:
     return candidate
 
 
-class MissingPipdirError(Exception):
-    def __init__(self, msg: str, *args: Any):
-        super().__init__(msg, *args)
-        self.msg = msg
+class MissingPipdirError(CommandError):
+    pass
 
 
-class MissingSlurmTmpdirError(Exception):
-    def __init__(self, msg: str, *args: Any):
-        super().__init__(msg, *args)
-        self.msg = msg
+class MissingSlurmTmpdirError(CommandError):
+    pass
 
 
 @overload
@@ -154,11 +150,7 @@ def _load(
         )
         return 1
 
-    try:
-        venv_cache = VenvCache()
-    except MissingPipdirError as err:
-        print(err.msg)
-        return 1
+    venv_cache = VenvCache()
 
     if not name or name not in venv_cache:
         print("Valid venvs:\n\t" + "\n\t".join(venv_cache))
@@ -229,11 +221,7 @@ def _save(name: str = positional(), force: bool = flag(match=["--force", "-f"]))
             "No active virtual env detected. Please activate one, or ensure "
             "$VIRTUAL_ENV is being set correctly"
         )
-    try:
-        venv_cache = VenvCache()
-    except MissingPipdirError as err:
-        print(err.msg)
-        return
+    venv_cache = VenvCache()
 
     delete = False
     if name in venv_cache:
@@ -359,11 +347,7 @@ def _activate(name: str = positional(), script: list[str] = keyword(["--script"]
 
     Only works on compute nodes. Use kpy create or kpy load --as on a login node
     """
-    try:
-        slurm_tmp = _get_slurm_tmpdir(False)
-    except MissingSlurmTmpdirError as err:
-        print(err.msg)
-        return 1
+    slurm_tmp = _get_slurm_tmpdir(False)
 
     index = KpyIndex(slurm_tmp)
     name = name
@@ -398,11 +382,7 @@ def _list():
 
     To list saved venvs, run `kpy load` without any arguments
     """
-    try:
-        slurm_tmp = _get_slurm_tmpdir(False)
-    except MissingSlurmTmpdirError as err:
-        print(err.msg)
-        return 1
+    slurm_tmp = _get_slurm_tmpdir(False)
     index = KpyIndex(slurm_tmp)
     print("\n".join(index))
 


### PR DESCRIPTION
Adds a typer like interface to define CLI args. Instead of creating a separate model class, the args can be defined directly in the function signature as parameters. Definitions work in exactly the same way (`name: annotation = arg_type(...)`) and get transparently converted into an attrs class.

A few bonuses:
* `@command` will catch `CommandError` or any subclass, and will exit the CLI with error code 1, allowing easy exits. Before exiting, the `msg` attribute of the error will be printed.
* `kpy create` will attempt to discover the currently activated python module (tested on compute canada graham servers). If it doesn't find anything, it will silently fall back to the old way of using the pipx installation version of python (i.e. python 3.9 or 3.10). When it works, this will hoepfully provide a more natural experience.