### PR TITLE
Interactive setting  of account variable

### DIFF
--- a/kslurm/appconfig.py
+++ b/kslurm/appconfig.py
@@ -15,7 +15,7 @@ def _load_config():
     if not _STATE["config"]:
         if not CONFIG_PATH.exists():
             CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-            with CONFIG_PATH.open('w') as f:
+            with CONFIG_PATH.open("w") as f:
                 json.dump({}, f)
         try:
             with CONFIG_PATH.open("r") as f:
@@ -30,8 +30,24 @@ def get_config(entity: str) -> Optional[str]:
     return _STATE["config"].get(entity, None)
 
 
+def get_config_children(entity: str):
+    _load_config()
+    for key, value in _STATE["config"].items():
+        if key.startswith(entity + "."):
+            yield key, value
+
+
 def set_config(entity: str, value: str):
     _load_config()
     _STATE["config"][entity] = value
+    with CONFIG_PATH.open("w") as f:
+        json.dump(_STATE["config"], f)
+    print(_STATE["config"])
+
+
+def unset_config(entity: str):
+    _load_config()
+    if entity in _STATE["config"]:
+        del _STATE["config"][entity]
     with CONFIG_PATH.open("w") as f:
         json.dump(_STATE["config"], f)

--- a/kslurm/cli/config.py
+++ b/kslurm/cli/config.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 
 import re
 import subprocess as sp
-from typing import DefaultDict
+from typing import Any, DefaultDict
 
 from InquirerPy import inquirer as inq  # type: ignore
-from InquirerPy.base.control import Choice  # type: ignore
+from InquirerPy.base import Choice  # type: ignore
 
 import kslurm.appconfig as appconfig
 from kslurm.args import flag, positional
@@ -19,7 +19,7 @@ class InteractiveConfigError(CommandError):
 def _get_account_type(
     accounts: dict[str, set[str]], levelfs: dict[str, str], label: str
 ) -> str:
-    choices = [
+    choices: list[Any] = [
         Choice(account, f"{account} (LevelFS: {levelfs[account + '_' + label]})")
         for account, types in accounts.items()
         if label in types

--- a/kslurm/cli/config.py
+++ b/kslurm/cli/config.py
@@ -93,20 +93,24 @@ def config(
     interactive: bool = flag(["--interactive", "-i"]),
 ):
     """Read and write from the kslurm config"""
+    config = appconfig.Config()
     if interactive:
         if entry not in INTERACTIVE_SETTINGS:
             raise InteractiveConfigError(f"{entry} can not be updated interactively")
         for key, new_value in INTERACTIVE_SETTINGS[entry]().items():
             if new_value is not None:
-                appconfig.set_config(key, new_value)
+                config[key] = new_value
                 continue
-            appconfig.unset_config(key)
+            if key in config:
+                del config[key]
+        config.write()
         return
     if not value:
-        curr_value = appconfig.get_config(entry)
+        curr_value = config.get(entry)
         print(curr_value or "")
-        for key, value in appconfig.get_config_children(entry):
+        for key, value in config.get_children(entry):
             print(f"{key}: {value}")
 
     else:
-        appconfig.set_config(entry, value)
+        config[entry] = value
+        config.write()

--- a/kslurm/cli/config.py
+++ b/kslurm/cli/config.py
@@ -107,7 +107,8 @@ def config(
         return
     if not value:
         curr_value = config.get(entry)
-        print(curr_value or "")
+        if curr_value is not None:
+            print(curr_value)
         for key, value in config.get_children(entry):
             print(f"{key}: {value}")
 

--- a/kslurm/cli/config.py
+++ b/kslurm/cli/config.py
@@ -1,31 +1,112 @@
 from __future__ import absolute_import
 
-import attr
+import re
+import subprocess as sp
+from typing import DefaultDict
+
+from InquirerPy import inquirer as inq  # type: ignore
+from InquirerPy.base.control import Choice  # type: ignore
 
 import kslurm.appconfig as appconfig
-from kslurm.args import positional
-from kslurm.args.command import command
+from kslurm.args import flag, positional
+from kslurm.args.command import CommandError, command
 
 
-@attr.frozen
-class ConfigModel:
-    entry: str = positional(help="Configuration value to update")
+class InteractiveConfigError(CommandError):
+    pass
+
+
+def _get_account_type(
+    accounts: dict[str, set[str]], levelfs: dict[str, str], label: str
+) -> str:
+    choices = [
+        Choice(account, f"{account} (LevelFS: {levelfs[account + '_' + label]})")
+        for account, types in accounts.items()
+        if label in types
+    ]
+    if not choices:
+        print(f"No {label}-enabled accounts available. Skipping.")
+        return ""
+    elif len(choices) == 1:
+        print(f"One {label}-enabled account available: {choices[0]}")
+        return choices[0].value
+    else:
+        return inq.fuzzy(
+            f"Select an account for {label} jobs. Higher LevelFS is better.",
+            choices=choices,
+        ).execute()
+
+
+def _account():
+    whoami = sp.run(["whoami"], capture_output=True).stdout.decode().strip()
+    proc = sp.run(
+        [
+            "sacctmgr",
+            "list",
+            "user",
+            "WithAssoc",
+            f"Names={whoami}",
+            "Format=Account",
+            "-Pn",
+        ],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        raise InteractiveConfigError(
+            "sacctmgr command not available. Cannot interactively set account."
+        )
+    accounts = set(proc.stdout.decode().strip().splitlines())
+    account_types: dict[str, set[str]] = DefaultDict(set)
+    account_fs: dict[str, str] = {}
+    for account in accounts:
+        if not (match := re.match(r"^([\w\-]+)_(cpu|gpu)$", account)):
+            continue
+        account_fs[account] = (
+            sp.run(
+                ["sshare", "-A", account, "-o", "LevelFS", "-hP"], capture_output=True
+            )
+            .stdout.decode()
+            .strip()
+            .splitlines()[0]
+        )
+        account_types[match[1]].add(match[2])
+    if not account_types:
+        raise InteractiveConfigError(
+            "No accounts found using sacctmgr. Cannot interactively set account."
+        )
+    cpu_choice = _get_account_type(account_types, account_fs, "cpu")
+    gpu_choice = _get_account_type(account_types, account_fs, "gpu")
+    return {"account.gpu": gpu_choice, "account.cpu": cpu_choice, "account": None}
+
+
+INTERACTIVE_SETTINGS = {"account": _account}
+
+
+@command(typer=True)
+def config(
+    entry: str = positional(help="Configuration value to update"),
     value: str = positional(
         default="",
         help="Updated value for config entry. If not provided, the current config "
         "value is printed",
-    )
-
-
-@command
-def config(args: ConfigModel):
+    ),
+    interactive: bool = flag(["--interactive", "-i"]),
+):
     """Read and write from the kslurm config"""
-    if not args.value:
-        value = appconfig.get_config(args.entry)
-        if value is None:
-            print("")
-        else:
-            print(value)
+    if interactive:
+        if entry not in INTERACTIVE_SETTINGS:
+            raise InteractiveConfigError(f"{entry} can not be updated interactively")
+        for key, new_value in INTERACTIVE_SETTINGS[entry]().items():
+            if new_value is not None:
+                appconfig.set_config(key, new_value)
+                continue
+            appconfig.unset_config(key)
+        return
+    if not value:
+        curr_value = appconfig.get_config(entry)
+        print(curr_value or "")
+        for key, value in appconfig.get_config_children(entry):
+            print(f"{key}: {value}")
 
     else:
-        appconfig.set_config(args.entry, args.value)
+        appconfig.set_config(entry, value)

--- a/kslurm/cli/main.py
+++ b/kslurm/cli/main.py
@@ -42,12 +42,12 @@ class KslurmModel:
 
 
 @command
-def main(args: KslurmModel, tail: list[str]) -> None:
+def main(args: KslurmModel, tail: list[str]) -> int:
     name, func = args.command
     entry = f"kslurm {name}"
     if name == "update":
         install(tail, NAME, HOME_DIR, ENTRYPOINTS)
-    func([entry, *tail])
+    return func([entry, *tail])
 
 
 if __name__ == "__main__":

--- a/kslurm/slurm/slurm_command.py
+++ b/kslurm/slurm/slurm_command.py
@@ -54,13 +54,14 @@ class SlurmCommand:
 
         self.gpu = bool(args.gpu)
         self.x11 = bool(args.x11)
+        config = appconfig.Config()
         if not args.account:
             if self.gpu:
-                account = appconfig.get_config("account.gpu")
+                account = config.get("account.gpu")
             else:
-                account = appconfig.get_config("account.cpu")
+                account = config.get("account.cpu")
             if account is None:
-                account = appconfig.get_config("account")
+                account = config.get("account")
             if not account:
                 print(
                     "Account must either be specified using --account, or provided in "

--- a/kslurm/slurm/slurm_command.py
+++ b/kslurm/slurm/slurm_command.py
@@ -55,14 +55,20 @@ class SlurmCommand:
         self.gpu = bool(args.gpu)
         self.x11 = bool(args.x11)
         if not args.account:
-            self.account = appconfig.get_config("account")
-            if not self.account:
+            if self.gpu:
+                account = appconfig.get_config("account.gpu")
+            else:
+                account = appconfig.get_config("account.cpu")
+            if account is None:
+                account = appconfig.get_config("account")
+            if not account:
                 print(
                     "Account must either be specified using --account, or provided in "
                     "config. A default account can be added to config by running "
                     "kslurm config account <account_name>"
                 )
                 sys.exit(1)
+            self.account = account
         else:
             self.account = args.account[0]
         self.cwd = args.directory

--- a/kslurm/venv.py
+++ b/kslurm/venv.py
@@ -5,7 +5,7 @@ import re
 from collections import UserDict
 from pathlib import Path
 
-from kslurm.appconfig import get_config
+from kslurm.appconfig import Config
 from kslurm.args.command import CommandError
 
 
@@ -35,7 +35,7 @@ class KpyIndex(UserDict[str, str]):
 
 class VenvCache(UserDict[str, Path]):
     def __init__(self):
-        pipdir = get_config("pipdir")
+        pipdir = Config().get("pipdir")
         if pipdir is None:
             raise MissingPipdirError(
                 "pipdir not set. Please set pipdir using `kslurm config pipdir "

--- a/poetry.lock
+++ b/poetry.lock
@@ -358,6 +358,21 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "inquirerpy"
+version = "0.3.3"
+description = "Python port of Inquirer.js (A collection of common interactive command-line user interfaces)"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+pfzy = ">=0.3.1,<0.4.0"
+prompt-toolkit = ">=3.0.1,<4.0.0"
+
+[package.extras]
+docs = ["Sphinx (>=4.1.2,<5.0.0)", "furo (>=2021.8.17-beta.43,<2022.0.0)", "sphinx-copybutton (>=0.4.0,<0.5.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "myst-parser (>=0.15.1,<0.16.0)"]
+
+[[package]]
 name = "isort"
 version = "5.10.1"
 description = "A Python utility / library to sort Python imports."
@@ -651,6 +666,17 @@ python-versions = "*"
 ptyprocess = ">=0.5"
 
 [[package]]
+name = "pfzy"
+version = "0.3.4"
+description = "Python port of the fzy fuzzy string matching algorithm"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.extras]
+docs = ["Sphinx (>=4.1.2,<5.0.0)", "furo (>=2021.8.17-beta.43,<2022.0.0)", "myst-parser (>=0.15.1,<0.16.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.4.0,<0.5.0)"]
+
+[[package]]
 name = "pkginfo"
 version = "1.8.2"
 description = "Query metadatdata from sdists / bdists / installed packages."
@@ -757,6 +783,17 @@ nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 toml = "*"
 virtualenv = ">=20.0.8"
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.29"
+description = "Library for building powerful interactive command lines in Python"
+category = "main"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+wcwidth = "*"
 
 [[package]]
 name = "ptyprocess"
@@ -1115,6 +1152,14 @@ docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sp
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
 
 [[package]]
+name = "wcwidth"
+version = "0.2.5"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "webencodings"
 version = "0.5.1"
 description = "Character encoding aliases for legacy web content"
@@ -1155,7 +1200,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "3105914bae65e2fd1761bf9cca00ce61b996ad7e68e4a36e5cbe4b612444c0d1"
+content-hash = "389ce43f3101ab989a83ff0ac10190eb69b0234696b94e2663fda905f69e58d8"
 
 [metadata.files]
 appdirs = [
@@ -1395,6 +1440,10 @@ iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
+inquirerpy = [
+    {file = "InquirerPy-0.3.3-py3-none-any.whl", hash = "sha256:773ba1f1c82852e5289e9fb3956ee06ef113ec949e3614d277ce24fe7945021c"},
+    {file = "InquirerPy-0.3.3.tar.gz", hash = "sha256:29a1ace830d98730e0a2fc01b4484256491c182cdde93ad66ff602b1b510aaeb"},
+]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
     {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
@@ -1524,6 +1573,10 @@ pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
     {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
 ]
+pfzy = [
+    {file = "pfzy-0.3.4-py3-none-any.whl", hash = "sha256:5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96"},
+    {file = "pfzy-0.3.4.tar.gz", hash = "sha256:717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1"},
+]
 pkginfo = [
     {file = "pkginfo-1.8.2-py2.py3-none-any.whl", hash = "sha256:c24c487c6a7f72c66e816ab1796b96ac6c3d14d49338293d2141664330b55ffc"},
     {file = "pkginfo-1.8.2.tar.gz", hash = "sha256:542e0d0b6750e2e21c20179803e40ab50598d8066d51097a0e382cba9eb02bff"},
@@ -1551,6 +1604,10 @@ poetry-core = [
 pre-commit = [
     {file = "pre_commit-2.18.1-py2.py3-none-any.whl", hash = "sha256:02226e69564ebca1a070bd1f046af866aa1c318dbc430027c50ab832ed2b73f2"},
     {file = "pre_commit-2.18.1.tar.gz", hash = "sha256:5d445ee1fa8738d506881c5d84f83c62bb5be6b2838e32207433647e8e5ebe10"},
+]
+prompt-toolkit = [
+    {file = "prompt_toolkit-3.0.29-py3-none-any.whl", hash = "sha256:62291dad495e665fca0bda814e342c69952086afb0f4094d0893d357e5c78752"},
+    {file = "prompt_toolkit-3.0.29.tar.gz", hash = "sha256:bd640f60e8cecd74f0dc249713d433ace2ddc62b65ee07f96d358e0b152b6ea7"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -1733,6 +1790,10 @@ urllib3 = [
 virtualenv = [
     {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},
     {file = "virtualenv-20.14.1.tar.gz", hash = "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 webencodings = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -132,7 +132,7 @@ clikit = ">=0.6.0,<0.7.0"
 
 [[package]]
 name = "click"
-version = "8.1.2"
+version = "8.1.3"
 description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
@@ -195,7 +195,7 @@ python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "cryptography"
-version = "36.0.2"
+version = "37.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "dev"
 optional = false
@@ -210,7 +210,7 @@ docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling 
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools_rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
 name = "distlib"
@@ -274,7 +274,7 @@ lxml = ["lxml"]
 
 [[package]]
 name = "hypothesis"
-version = "6.43.3"
+version = "6.46.2"
 description = "A library for property-based testing"
 category = "dev"
 optional = false
@@ -302,7 +302,7 @@ zoneinfo = ["backports.zoneinfo (>=0.2.1)", "tzdata (>=2022.1)"]
 
 [[package]]
 name = "identify"
-version = "2.4.12"
+version = "2.5.0"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -769,7 +769,7 @@ importlib-metadata = {version = ">=1.7.0,<2.0.0", markers = "python_version >= \
 
 [[package]]
 name = "pre-commit"
-version = "2.18.1"
+version = "2.19.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -845,11 +845,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pygments"
-version = "2.11.2"
+version = "2.12.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [[package]]
 name = "pylev"
@@ -872,7 +872,7 @@ diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pytest"
-version = "7.1.1"
+version = "7.1.2"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
@@ -953,7 +953,7 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "rich"
-version = "12.2.0"
+version = "12.3.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 category = "main"
 optional = false
@@ -1040,7 +1040,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "tomlkit"
-version = "0.10.1"
+version = "0.10.2"
 description = "Style preserving TOML library"
 category = "dev"
 optional = false
@@ -1200,7 +1200,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "389ce43f3101ab989a83ff0ac10190eb69b0234696b94e2663fda905f69e58d8"
+content-hash = "db3df47bb8921b79215de75cab183078a76ec5d92987d741c63e6db67f409888"
 
 [metadata.files]
 appdirs = [
@@ -1312,8 +1312,8 @@ cleo = [
     {file = "cleo-0.8.1.tar.gz", hash = "sha256:3d0e22d30117851b45970b6c14aca4ab0b18b1b53c8af57bed13208147e4069f"},
 ]
 click = [
-    {file = "click-8.1.2-py3-none-any.whl", hash = "sha256:24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e"},
-    {file = "click-8.1.2.tar.gz", hash = "sha256:479707fe14d9ec9a0757618b7a100a0ae4c4e236fac5b7f80ca68028141a1a72"},
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 clikit = [
     {file = "clikit-0.6.2-py2.py3-none-any.whl", hash = "sha256:71268e074e68082306e23d7369a7b99f824a0ef926e55ba2665e911f7208489e"},
@@ -1375,26 +1375,28 @@ crashtest = [
     {file = "crashtest-0.3.1.tar.gz", hash = "sha256:42ca7b6ce88b6c7433e2ce47ea884e91ec93104a4b754998be498a8e6c3d37dd"},
 ]
 cryptography = [
-    {file = "cryptography-36.0.2-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:4e2dddd38a5ba733be6a025a1475a9f45e4e41139d1321f412c6b360b19070b6"},
-    {file = "cryptography-36.0.2-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:4881d09298cd0b669bb15b9cfe6166f16fc1277b4ed0d04a22f3d6430cb30f1d"},
-    {file = "cryptography-36.0.2-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea634401ca02367c1567f012317502ef3437522e2fc44a3ea1844de028fa4b84"},
-    {file = "cryptography-36.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:7be666cc4599b415f320839e36367b273db8501127b38316f3b9f22f17a0b815"},
-    {file = "cryptography-36.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8241cac0aae90b82d6b5c443b853723bcc66963970c67e56e71a2609dc4b5eaf"},
-    {file = "cryptography-36.0.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b2d54e787a884ffc6e187262823b6feb06c338084bbe80d45166a1cb1c6c5bf"},
-    {file = "cryptography-36.0.2-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:c2c5250ff0d36fd58550252f54915776940e4e866f38f3a7866d92b32a654b86"},
-    {file = "cryptography-36.0.2-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:ec6597aa85ce03f3e507566b8bcdf9da2227ec86c4266bd5e6ab4d9e0cc8dab2"},
-    {file = "cryptography-36.0.2-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:ca9f686517ec2c4a4ce930207f75c00bf03d94e5063cbc00a1dc42531511b7eb"},
-    {file = "cryptography-36.0.2-cp36-abi3-win32.whl", hash = "sha256:f64b232348ee82f13aac22856515ce0195837f6968aeaa94a3d0353ea2ec06a6"},
-    {file = "cryptography-36.0.2-cp36-abi3-win_amd64.whl", hash = "sha256:53e0285b49fd0ab6e604f4c5d9c5ddd98de77018542e88366923f152dbeb3c29"},
-    {file = "cryptography-36.0.2-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:32db5cc49c73f39aac27574522cecd0a4bb7384e71198bc65a0d23f901e89bb7"},
-    {file = "cryptography-36.0.2-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b3d199647468d410994dbeb8cec5816fb74feb9368aedf300af709ef507e3e"},
-    {file = "cryptography-36.0.2-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:da73d095f8590ad437cd5e9faf6628a218aa7c387e1fdf67b888b47ba56a17f0"},
-    {file = "cryptography-36.0.2-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:0a3bf09bb0b7a2c93ce7b98cb107e9170a90c51a0162a20af1c61c765b90e60b"},
-    {file = "cryptography-36.0.2-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8897b7b7ec077c819187a123174b645eb680c13df68354ed99f9b40a50898f77"},
-    {file = "cryptography-36.0.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82740818f2f240a5da8dfb8943b360e4f24022b093207160c77cadade47d7c85"},
-    {file = "cryptography-36.0.2-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:1f64a62b3b75e4005df19d3b5235abd43fa6358d5516cfc43d87aeba8d08dd51"},
-    {file = "cryptography-36.0.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:e167b6b710c7f7bc54e67ef593f8731e1f45aa35f8a8a7b72d6e42ec76afd4b3"},
-    {file = "cryptography-36.0.2.tar.gz", hash = "sha256:70f8f4f7bb2ac9f340655cbac89d68c527af5bb4387522a8413e841e3e6628c9"},
+    {file = "cryptography-37.0.2-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:ef15c2df7656763b4ff20a9bc4381d8352e6640cfeb95c2972c38ef508e75181"},
+    {file = "cryptography-37.0.2-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:3c81599befb4d4f3d7648ed3217e00d21a9341a9a688ecdd615ff72ffbed7336"},
+    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2bd1096476aaac820426239ab534b636c77d71af66c547b9ddcd76eb9c79e004"},
+    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:31fe38d14d2e5f787e0aecef831457da6cec68e0bb09a35835b0b44ae8b988fe"},
+    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:093cb351031656d3ee2f4fa1be579a8c69c754cf874206be1d4cf3b542042804"},
+    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59b281eab51e1b6b6afa525af2bd93c16d49358404f814fe2c2410058623928c"},
+    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:0cc20f655157d4cfc7bada909dc5cc228211b075ba8407c46467f63597c78178"},
+    {file = "cryptography-37.0.2-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:f8ec91983e638a9bcd75b39f1396e5c0dc2330cbd9ce4accefe68717e6779e0a"},
+    {file = "cryptography-37.0.2-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:46f4c544f6557a2fefa7ac8ac7d1b17bf9b647bd20b16decc8fbcab7117fbc15"},
+    {file = "cryptography-37.0.2-cp36-abi3-win32.whl", hash = "sha256:731c8abd27693323b348518ed0e0705713a36d79fdbd969ad968fbef0979a7e0"},
+    {file = "cryptography-37.0.2-cp36-abi3-win_amd64.whl", hash = "sha256:471e0d70201c069f74c837983189949aa0d24bb2d751b57e26e3761f2f782b8d"},
+    {file = "cryptography-37.0.2-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a68254dd88021f24a68b613d8c51d5c5e74d735878b9e32cc0adf19d1f10aaf9"},
+    {file = "cryptography-37.0.2-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:a7d5137e556cc0ea418dca6186deabe9129cee318618eb1ffecbd35bee55ddc1"},
+    {file = "cryptography-37.0.2-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:aeaba7b5e756ea52c8861c133c596afe93dd716cbcacae23b80bc238202dc023"},
+    {file = "cryptography-37.0.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95e590dd70642eb2079d280420a888190aa040ad20f19ec8c6e097e38aa29e06"},
+    {file = "cryptography-37.0.2-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:1b9362d34363f2c71b7853f6251219298124aa4cc2075ae2932e64c91a3e2717"},
+    {file = "cryptography-37.0.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:e53258e69874a306fcecb88b7534d61820db8a98655662a3dd2ec7f1afd9132f"},
+    {file = "cryptography-37.0.2-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:1f3bfbd611db5cb58ca82f3deb35e83af34bb8cf06043fa61500157d50a70982"},
+    {file = "cryptography-37.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:419c57d7b63f5ec38b1199a9521d77d7d1754eb97827bbb773162073ccd8c8d4"},
+    {file = "cryptography-37.0.2-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:dc26bb134452081859aa21d4990474ddb7e863aa39e60d1592800a8865a702de"},
+    {file = "cryptography-37.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:3b8398b3d0efc420e777c40c16764d6870bcef2eb383df9c6dbb9ffe12c64452"},
+    {file = "cryptography-37.0.2.tar.gz", hash = "sha256:f224ad253cc9cea7568f49077007d2263efa57396a2f2f78114066fd54b5c68e"},
 ]
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
@@ -1417,12 +1419,12 @@ html5lib = [
     {file = "html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"},
 ]
 hypothesis = [
-    {file = "hypothesis-6.43.3-py3-none-any.whl", hash = "sha256:b8588f4b6511481dd967686db2915104d547899e441af4d670fc1a3051cae573"},
-    {file = "hypothesis-6.43.3.tar.gz", hash = "sha256:8580703d83cf9552489195e9c603047efde56d1551d6df1d22f11055186dc734"},
+    {file = "hypothesis-6.46.2-py3-none-any.whl", hash = "sha256:37ca37f61939d0a92c18b5e17ab8088dccc5fc077c913d6619bbe1d233dfca1e"},
+    {file = "hypothesis-6.46.2.tar.gz", hash = "sha256:c671b3801527f3a8189314d9385418a67d4c7ab1b3330a3ff8b267d0d4599b3d"},
 ]
 identify = [
-    {file = "identify-2.4.12-py2.py3-none-any.whl", hash = "sha256:5f06b14366bd1facb88b00540a1de05b69b310cbc2654db3c7e07fa3a4339323"},
-    {file = "identify-2.4.12.tar.gz", hash = "sha256:3f3244a559290e7d3deb9e9adc7b33594c1bc85a9dd82e0f1be519bf12a1ec17"},
+    {file = "identify-2.5.0-py2.py3-none-any.whl", hash = "sha256:3acfe15a96e4272b4ec5662ee3e231ceba976ef63fd9980ed2ce9cc415df393f"},
+    {file = "identify-2.5.0.tar.gz", hash = "sha256:c83af514ea50bf2be2c4a3f2fb349442b59dc87284558ae9ff54191bff3541d2"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -1602,8 +1604,8 @@ poetry-core = [
     {file = "poetry_core-1.0.8-py2.py3-none-any.whl", hash = "sha256:54b0fab6f7b313886e547a52f8bf52b8cf43e65b2633c65117f8755289061924"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.18.1-py2.py3-none-any.whl", hash = "sha256:02226e69564ebca1a070bd1f046af866aa1c318dbc430027c50ab832ed2b73f2"},
-    {file = "pre_commit-2.18.1.tar.gz", hash = "sha256:5d445ee1fa8738d506881c5d84f83c62bb5be6b2838e32207433647e8e5ebe10"},
+    {file = "pre_commit-2.19.0-py2.py3-none-any.whl", hash = "sha256:10c62741aa5704faea2ad69cb550ca78082efe5697d6f04e5710c3c229afdd10"},
+    {file = "pre_commit-2.19.0.tar.gz", hash = "sha256:4233a1e38621c87d9dda9808c6606d7e7ba0e087cd56d3fe03202a01d2919615"},
 ]
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.29-py3-none-any.whl", hash = "sha256:62291dad495e665fca0bda814e342c69952086afb0f4094d0893d357e5c78752"},
@@ -1634,8 +1636,8 @@ pyflakes = [
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pygments = [
-    {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
-    {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
+    {file = "Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
+    {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
 ]
 pylev = [
     {file = "pylev-1.4.0-py2.py3-none-any.whl", hash = "sha256:7b2e2aa7b00e05bb3f7650eb506fc89f474f70493271a35c242d9a92188ad3dd"},
@@ -1646,8 +1648,8 @@ pyparsing = [
     {file = "pyparsing-3.0.8.tar.gz", hash = "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954"},
 ]
 pytest = [
-    {file = "pytest-7.1.1-py3-none-any.whl", hash = "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"},
-    {file = "pytest-7.1.1.tar.gz", hash = "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63"},
+    {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
+    {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
 ]
 pytest-mock = [
     {file = "pytest-mock-3.7.0.tar.gz", hash = "sha256:5112bd92cc9f186ee96e1a92efc84969ea494939c3aead39c50f421c4cc69534"},
@@ -1701,8 +1703,8 @@ requests-toolbelt = [
     {file = "requests_toolbelt-0.9.1-py2.py3-none-any.whl", hash = "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f"},
 ]
 rich = [
-    {file = "rich-12.2.0-py3-none-any.whl", hash = "sha256:c50f3d253bc6a9bb9c79d61a26d510d74abdf1b16881260fab5edfc3edfb082f"},
-    {file = "rich-12.2.0.tar.gz", hash = "sha256:ea74bc9dad9589d8eea3e3fd0b136d8bf6e428888955f215824c2894f0da8b47"},
+    {file = "rich-12.3.0-py3-none-any.whl", hash = "sha256:0eb63013630c6ee1237e0e395d51cb23513de6b5531235e33889e8842bdf3a6f"},
+    {file = "rich-12.3.0.tar.gz", hash = "sha256:7e8700cda776337036a712ff0495b04052fb5f957c7dfb8df997f88350044b64"},
 ]
 secretstorage = [
     {file = "SecretStorage-3.3.2-py3-none-any.whl", hash = "sha256:755dc845b6ad76dcbcbc07ea3da75ae54bb1ea529eb72d15f83d26499a5df319"},
@@ -1737,8 +1739,8 @@ tomli = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.10.1-py3-none-any.whl", hash = "sha256:3eba517439dcb2f84cf39f4f85fd2c3398309823a3c75ac3e73003638daf7915"},
-    {file = "tomlkit-0.10.1.tar.gz", hash = "sha256:3c517894eadef53e9072d343d37e4427b8f0b6200a70b7c9a19b2ebd1f53b951"},
+    {file = "tomlkit-0.10.2-py3-none-any.whl", hash = "sha256:905cf92c2111ef80d355708f47ac24ad1b6fc2adc5107455940088c9bbecaedb"},
+    {file = "tomlkit-0.10.2.tar.gz", hash = "sha256:30d54c0b914e595f3d10a87888599eab5321a2a69abc773bbefff51599b72db6"},
 ]
 tox = [
     {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ appdirs = "^1.4.4"
 shellingham = "^1.4.0"
 virtualenv = ">=20.0.24,<21"
 docstring-parser = "^0.14.1"
-inquirerpy = "^0.3.3"
+InquirerPy = "^0.3.3"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"
@@ -77,6 +77,7 @@ strict = ["kslurm/**"]
 include = ["kslurm"]
 exclude = ["kslurm/test/", "**/__pycache__", "**/node_modules", ".git"]
 venv = ".venv"
+useLibraryCodeForTypes = true
 
 [tool.black]
 extend-exclude = ["typings/.*$", "neuroglia_helpers/.*$"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ appdirs = "^1.4.4"
 shellingham = "^1.4.0"
 virtualenv = ">=20.0.24,<21"
 docstring-parser = "^0.14.1"
+inquirerpy = "^0.3.3"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"


### PR DESCRIPTION
Adds an `-i` flag to `kslurm config` to allow the interactive updating of supported variables. Currently just `account` is supported. Sets separate accounts for both cpu and gpu. The interactive list shows the `LevelFS` for each account.

Two account types are set to `account.cpu` and `account.gpu`. `account` becomes unset, but is still read by slurm as a fallback. If `kslurm config account` is run, all three values, if set, will be printed.