### PR TITLE
Jupyter autoinstall

### DIFF
--- a/kslurm/cli/kjupyter.py
+++ b/kslurm/cli/kjupyter.py
@@ -65,11 +65,12 @@ def kjupyter(
                 [
                     "source",
                     str(path),
-                    "&&",
-                    "kpy",
-                    "load",
+                    "; ",
+                    "kpy load",
                     args.venv[0],
-                    "&&",
+                    "; ",
+                    "command -v jupyter-lab > /dev/null || (echo 'jupyter-lab not "
+                    "found, attempting install' && pip install jupyterlab);",
                 ]
                 if args.venv
                 else []
@@ -126,9 +127,13 @@ def kjupyter(
                     port = url.group(2)
                     path = url.group(3)
                     try:
-                        hostname = sp.run(
-                            ["wget", "-qO-", "ipinfo.io/ip"], capture_output=True
-                        ).stdout.decode().strip()
+                        hostname = (
+                            sp.run(
+                                ["wget", "-qO-", "ipinfo.io/ip"], capture_output=True
+                            )
+                            .stdout.decode()
+                            .strip()
+                        )
                     except RuntimeError:
                         hostname = "<hostname>"
                     console.print(
@@ -137,9 +142,9 @@ def kjupyter(
                             domain=domain,
                             path=path,
                             url=url.group(0),
-                            username=sp.run(
-                                ["whoami"], capture_output=True
-                            ).stdout.decode().strip(),
+                            username=sp.run(["whoami"], capture_output=True)
+                            .stdout.decode()
+                            .strip(),
                             hostname=hostname,
                         )
                     )

--- a/kslurm/cli/kjupyter.py
+++ b/kslurm/cli/kjupyter.py
@@ -44,6 +44,7 @@ def kjupyter(
     jupyter-lab.
     """
     slurm = SlurmCommand(args, command_args, arglist)
+    slurm.name = "jupyter"
     assert isinstance(args, JupyterModel)
 
     if args.venv:

--- a/kslurm/slurm/slurm_command.py
+++ b/kslurm/slurm/slurm_command.py
@@ -123,6 +123,8 @@ class SlurmCommand:
             s += " --gres=gpu:1"
         if self.x11:
             s += " --x11"
+        if self.name:
+            s += f" --job-name='{self.name}'"
         return s
 
     @property
@@ -156,10 +158,7 @@ class SlurmCommand:
         if self.test:
             s = "cat"
         else:
-            s = (
-                f"sbatch {self.slurm_args} --job-name={self.name} "
-                f"--parsable {self.output}"
-            )
+            s = f"sbatch {self.slurm_args} " f"--parsable {self.output}"
         if self.command:
             return f"echo '{self.script}' | {s}"
         else:

--- a/kslurm/slurm/slurm_command.py
+++ b/kslurm/slurm/slurm_command.py
@@ -96,10 +96,7 @@ class SlurmCommand:
 
     @property
     def name(self):
-        if not self._name:
-            return self._command[0]
-        else:
-            return self._name
+        return self._name
 
     @name.setter
     def name(self, name: str):

--- a/kslurm/test/test_batch.py
+++ b/kslurm/test/test_batch.py
@@ -60,7 +60,7 @@ def test_params_can_be_altered(capsys: CaptureFixture[str]):
         subprocess.assert_called_once_with(
             "echo '#!/bin/bash\ncommand' | sbatch --account=some-account "
             "--time=2-09:11:00 --cpus-per-task=8 --mem=5000 --gres=gpu:1 "
-            "--job-name=command --parsable ",
+            "--parsable ",
             shell=True,
             stdout=-1,
             stderr=-2,


### PR DESCRIPTION
This allows jupyter to be autoinstalled in venvs that don't have jupyter.

It also fixes some issues with job name in slurm commands, and the variable is used in all commands (sbatch, salloc, srun).