### PR TITLE
Fix kbatch treatment of scripts and in-job krun

### DIFF
--- a/kslurm/slurm/slurm_command.py
+++ b/kslurm/slurm/slurm_command.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import os
 import shlex
 import sys
+from pathlib import Path
 from typing import List, Union
 
 import kslurm.appconfig as appconfig
@@ -150,6 +151,8 @@ class SlurmCommand:
     @property
     def run(self):
         if self.command:
+            if os.environ.get("SLURM_JOB_ID") or os.environ.get("SLURM_JOBID"):
+                return f"srun {self.slurm_args} {self.command}"
             return f"srun {self.slurm_args} bash -c {shlex.quote(self.command)}"
         else:
             return f"salloc {self.slurm_args}"
@@ -161,6 +164,8 @@ class SlurmCommand:
         else:
             s = f"sbatch {self.slurm_args} --parsable {self.output}"
         if self.command:
+            if Path(self._command[0]).is_file():
+                return f"{s} {self.command}"
             return f"echo {shlex.quote(self.script)} | {s}"
         else:
             raise ValidationError("No command given")


### PR DESCRIPTION
The docs promise that kbatch can read slurm batch files like normal (including reading `#SBATCH` directives), but this actually was never the case. This PR fixes that.

`krun` previously took the user supplied command and fed it to `srun` through bash, so the entire command, include pipes `|` or redirects `>` went through the same process. This behaviour is retained for login-node calls of `krun` that start a new allocation, but `krun` calls within a job will more exactly mirror `srun`. So `krun command arg1 arg2 == srun command arg2 arg2`