### PR TITLE
Add simple caching for kpy bash

### DIFF
--- a/kslurm/bin/bash.sh
+++ b/kslurm/bin/bash.sh
@@ -1,33 +1,59 @@
-# This represents a fairly significant load time for shells. A clever way of caching would be ideal
-if [[ -z $KSLURM_COMPUTE_NODES ]]; then
-  export KSLURM_COMPUTE_NODES=$(sinfo -N -h | awk '{print $1'} | sort -u)
+# vars that are cached:
+# KSLURM_COMPUTE_NODES
+# PIP_WHEEL_DIR
+
+cache=~/.cache/kslurm/kpy_cache.sh
+nodes=~/.cache/kslurm/kpy_cache.nodes
+
+# resets the cache using the 'reset' arg
+if [ "$#" -gt 0 ]
+then
+    if [ "$1" = "reset" -a -e "${cache}" ]
+    then 
+      echo "Resetting cache at $cache"
+      rm -f $cache
+    fi
 fi
 
+if [ -e "$cache" ]
+then
+  source $cache
+else
+  echo "#cache created on `date`" > $cache
+  sinfo -N -h | awk '{print $1}' | sort -u > $nodes
+  echo "export KSLURM_COMPUTE_NODES=\`cat $nodes\`" >> $cache
+
+  if command -v kslurm &> /dev/null; then
+    pipdir=$(kslurm config pipdir)
+    if [[ -z $pipdir ]]; then
+      echo "pipdir has not been defined. Please set a pipdir using \`kslurm config pipdir <directory>\`. Typically, this should be a directory in a project space or permanent storage directory."
+    else
+      wheelhouse="${pipdir%/}/wheels"
+      if [[ ! -d "$wheelhouse" ]]; then
+        mkdir -p "$wheelhouse"
+      fi
+      echo "export PIP_WHEEL_DIR=$wheelhouse" >> $cache
+    fi
+  else
+    echo "kslurm program was not found on \$PATH. If installed in a virtualenv, be sure the env is activated."
+  fi
+fi
+
+
+
 pip () {
-  local installing installtype cmd pipdir wheelhouse
+  local installing installtype cmd wheelhouse
   [[ $1 == install || $1 == uninstall ]] && installing=1 || installing=
   [[ $1 == install || $1 == wheel || $1 == download ]] && installtype=1 || installtype=
   cmd=$1
   if [[ $KSLURM_COMPUTE_NODES =~ $(hostname) && -n $installtype ]]; then
     cmd="$cmd --no-index"
   fi
+
   if [[ -n $installtype ]]; then
-    if command -v kslurm &> /dev/null; then
-      pipdir=$(kslurm config pipdir)
-      if [[ -z $pipdir ]]; then
-        echo "pipdir has not been defined. Please set a pipdir using \`kslurm config pipdir <directory>\`. Typically, this should be a directory in a project space or permanent storage directory."
-      else
-        wheelhouse="${pipdir%/}/wheels"
-        if [[ ! -d "$wheelhouse" ]]; then
-          mkdir -p "$wheelhouse"
-        fi
-        cmd="$cmd --find-links=$wheelhouse"
-        export PIP_WHEEL_DIR=$wheelhouse
-      fi
-    else
-      echo "kslurm program was not found on \$PATH. If installed in a virtualenv, be sure the env is activated."
-    fi
+    cmd="$cmd --find-links=$PIP_WHEEL_DIR"
   fi
+
   shift
   command pip $cmd $@
   if [[ -n $installing ]]; then


### PR DESCRIPTION
If the cache doesn't exist (or if reset flag is used), a kpy_cache.sh script is created that initializes KSLURM_COMPUTE_NODES and PIP_WHEEL_DIR. I use another file to store the list of nodes since it was quite long to encode inline.

Kept everything else identical (just moved to the cache generation). 