### PR TITLE
Add time flag in kapp

### DIFF
--- a/kslurm/cli/kapp/main.py
+++ b/kslurm/cli/kapp/main.py
@@ -75,6 +75,10 @@ def _pull(
         ["--mem"],
         format=formatters.mem,
         help="Amount of memory to allocate when building image",
+    ),
+    time: int = keyword(
+        ["--time"],
+        help="Amount of time in hours to allocate when building image"
     )
     # executable: bool = flag(
     #     ["-x", "--exe"], help="Include --name as an executable on the $PATH"
@@ -167,10 +171,15 @@ def _pull(
         if mem
         else (min(64000, app.docker_data.size_mb * 20) if app.docker_data else 8000)
     )
+    time = (
+        time
+        if time
+        else ("1")
+    )
     ret = krun.cli(
         [
             "krun",
-            "1:00",
+            f"{time}:00",
             f"{mem}M",
             "singularity",
             "build",


### PR DESCRIPTION
The `kapp` CLI currently lacks a `--time` flag and defaults to allocating 1 hour for building an image. While this duration works well for small to medium-sized images, it often falls short for larger images like`docker://micalab/micapipe:v0.2.3`, where more time is needed to complete the pull and build processes. Adding a `--time` flag would allow users greater flexibility when working with larger images.

The --time flag would accept an integer input representing hours (e.g., [x:int]:00). Given that building an image rarely requires more than 24 hours, limiting the time allocation to hours should be sufficient for all use cases, including those with extensive build requirements.